### PR TITLE
use creation code to determine the init code hash

### DIFF
--- a/contracts/libraries/LiquidityUtil.sol
+++ b/contracts/libraries/LiquidityUtil.sol
@@ -14,8 +14,7 @@ library LiquidityUtil {
     using SafeCast for *;
     using UnsafeMath for *;
 
-    bytes32 internal constant LP_TOKEN_INIT_CODE_HASH =
-        0xf7ee18f8779e8a47b9fee2bf37816783fe8615833733cf03cc48cd8fc3e3128b;
+    bytes32 internal constant LP_TOKEN_INIT_CODE_HASH = keccak256(type(LPToken).creationCode);
 
     struct MintParam {
         IERC20 market;

--- a/contracts/libraries/PUSDManagerUtil.sol
+++ b/contracts/libraries/PUSDManagerUtil.sol
@@ -18,7 +18,7 @@ library PUSDManagerUtil {
     using UnsafeMath for *;
 
     bytes32 internal constant PUSD_SALT = keccak256("Pure USD");
-    bytes32 internal constant PUSD_INIT_CODE_HASH = 0x833a3129a7c49096ba2bc346ab64e2bbec674f4181bf8e6dedfa83aea7fb0fec;
+    bytes32 internal constant PUSD_INIT_CODE_HASH = keccak256(type(PUSD).creationCode);
 
     struct MintParam {
         IERC20 market;


### PR DESCRIPTION
```
> @purecash/pure-cash-contracts@0.0.1 build
> npx hardhat compile
Solidity 0.8.26 is not fully supported yet. You can still use Hardhat, but some features, like stack traces, might not work correctly.
Learn more at https://hardhat.org/hardhat-runner/docs/reference/solidity-support
Downloading compiler 0.8.26
An unexpected error occurred:
Error: Failed to compile modified contracts for namespaced storage:
TypeError: Member "creationCode" not found or not visible after argument-dependent lookup in type(contract LPToken).
  --> contracts/libraries/LiquidityUtil.sol:17:67:
   |
17 |     bytes32 internal constant LP_TOKEN_INIT_CODE_HASH = keccak256(type(LPToken).creationCode);
   |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
Please report this at https://zpl.in/upgrades/report. If possible, include the source code for the contracts mentioned in the errors above.
Error: Process completed with exit code 1.
```